### PR TITLE
bm25topk() call-chain optimization

### DIFF
--- a/plpgsql_bm25.sql
+++ b/plpgsql_bm25.sql
@@ -470,6 +470,6 @@ DECLARE
   docstname TEXT := tablename || '_' ||  columnname || '_bm25i_docs' || algo;
   wordstname TEXT := tablename || '_' ||  columnname || '_bm25i_words' || algo;
 BEGIN
-  RETURN QUERY EXECUTE FORMAT( 'SELECT t1.id, t2.score, t1.d AS doc FROM (SELECT id, doc AS d FROM %s) t1 INNER JOIN ( SELECT id, score FROM bm25isc_alt(%s,%s,%s) ) t2 ON ( t1.id = t2.id ) ORDER BY t2.score DESC LIMIT %s;', docstname, quote_literal(wordstname), quote_literal(mquery), quote_literal(stopwordslanguage), k );
+  RETURN QUERY EXECUTE FORMAT( 'SELECT t1.id, t2.score, t1.d AS doc FROM (SELECT id, doc AS d FROM %s) t1 INNER JOIN ( SELECT id, score FROM bm25isc(%s,%s,%s) ) t2 ON ( t1.id = t2.id ) ORDER BY t2.score DESC LIMIT %s;', docstname, quote_literal(wordstname), quote_literal(mquery), quote_literal(stopwordslanguage), k );
 END;
 $$;

--- a/plpgsql_bm25.sql
+++ b/plpgsql_bm25.sql
@@ -66,6 +66,8 @@
 DROP FUNCTION IF EXISTS stopwordfilter;
 CREATE OR REPLACE FUNCTION stopwordfilter(words TEXT[], language TEXT DEFAULT '') RETURNS TEXT[]
 LANGUAGE plpgsql
+IMMUTABLE
+PARALLEL SAFE
 AS $$
 DECLARE
   w TEXT;
@@ -127,6 +129,8 @@ $$;
 DROP FUNCTION IF EXISTS bm25simpletokenize;
 CREATE OR REPLACE FUNCTION bm25simpletokenize(txt TEXT) RETURNS TEXT[]
 LANGUAGE plpgsql
+IMMUTABLE
+PARALLEL SAFE
 AS $$
 DECLARE
   w TEXT;
@@ -408,15 +412,12 @@ $$;
 /* bm25scorerows() get the documentscores row for each word */
 DROP FUNCTION IF EXISTS bm25scorerows;
 CREATE OR REPLACE FUNCTION bm25scorerows(tablename TEXT, mquery TEXT, stopwordslanguage TEXT DEFAULT '') RETURNS SETOF double precision[]
-LANGUAGE plpgsql
+    LANGUAGE plpgsql
+    STABLE
+    PARALLEL SAFE
 AS $$
-DECLARE
-  w TEXT := '';
 BEGIN
-  FOR w IN SELECT unnest( stopwordfilter( bm25simpletokenize(mquery), stopwordslanguage ) )
-  LOOP
-    RETURN QUERY EXECUTE FORMAT( 'SELECT wsmap FROM %s WHERE word = %s;', tablename, quote_literal(w) );
-  END LOOP;
+    RETURN QUERY EXECUTE FORMAT('SELECT wsmap FROM %s w INNER JOIN unnest(stopwordfilter(bm25simpletokenize(%s), %s) n ON w.word = n.n;', tablename, quote_literal(mquery), stopwordslanguage);
 END;
 $$;
 
@@ -424,49 +425,51 @@ $$;
 /* bm25scoressum(): sums the score rows to one array with the document scores ; TODO: test whether temp table fixes race condition here */
 DROP FUNCTION IF EXISTS bm25scoressum;
 CREATE OR REPLACE FUNCTION bm25scoressum(tablename TEXT, mquery TEXT, stopwordslanguage TEXT DEFAULT '') RETURNS SETOF double precision[]
-LANGUAGE plpgsql
-AS $$
-DECLARE
-  xdocstname TEXT := tablename || '_bm25i_temp';
-BEGIN
-  EXECUTE FORMAT( 'DROP TABLE IF EXISTS %s;', xdocstname );
-  EXECUTE FORMAT( 'CREATE TEMPORARY TABLE %s AS SELECT bm25scorerows(%s, %s, %s);', xdocstname, quote_literal(tablename), quote_literal(mquery), quote_literal(stopwordslanguage) );
-  RETURN QUERY EXECUTE FORMAT( 'SELECT ARRAY_AGG(sum ORDER BY ord) FROM (SELECT ord, SUM(int) FROM %s, unnest(bm25scorerows) WITH ORDINALITY u(int, ord) GROUP BY ord) AS subquery;', xdocstname ); /* Issue #4 fix: AS subquery */
+LANGUAGE sql
+PARALLEL SAFE
+STABLE
+BEGIN ATOMIC
+    SELECT ARRAY_AGG(sum ORDER BY ord)
+    FROM (SELECT ord, SUM(int)
+          FROM (SELECT b.b
+                FROM bm25scorerows(tablename, quote_literal(mquery), quote_literal(stopwordslanguage)) b) t, unnest(t.b) WITH ORDINALITY u(int, ord)
+          GROUP BY ord) AS subquery;
 END;
-$$;
 
 
 /* bm25scunnest(): unnests the score array */
 DROP FUNCTION IF EXISTS bm25scunnest;
 CREATE OR REPLACE FUNCTION bm25scunnest(tablename TEXT, mquery TEXT, stopwordslanguage TEXT DEFAULT '') RETURNS TABLE(score double precision)
-LANGUAGE plpgsql
-AS $$
-BEGIN
-  RETURN QUERY SELECT unnest( bm25scoressum( tablename, mquery, stopwordslanguage ) );
+    LANGUAGE sql
+    PARALLEL SAFE
+    STABLE
+BEGIN ATOMIC
+    SELECT unnest( bm25scoressum( tablename, mquery, stopwordslanguage ) );
 END;
-$$;
 
 
 /* bm25isc(): returns the index and score of the documents; index starts with 1 */
 DROP FUNCTION IF EXISTS bm25isc;
 CREATE OR REPLACE FUNCTION bm25isc(tablename TEXT, mquery TEXT, stopwordslanguage TEXT DEFAULT '') RETURNS TABLE(id BIGINT, score double precision)
-LANGUAGE plpgsql
-AS $$
-BEGIN
-  RETURN QUERY SELECT row_number() OVER () AS id, bm25scunnest FROM bm25scunnest( tablename, mquery, stopwordslanguage ) ;
+    LANGUAGE sql
+    PARALLEL SAFE
+    STABLE
+BEGIN ATOMIC
+    SELECT row_number() OVER () AS id, bm25scunnest FROM bm25scunnest( tablename, mquery, stopwordslanguage ) ;
 END;
-$$;
 
 
 /* bm25topk(): returns the index, score and document sorted and limited |  TABLE(id INT, id2 BIGINT, score double precision, doc TEXT) */
 DROP FUNCTION IF EXISTS bm25topk;
 CREATE OR REPLACE FUNCTION bm25topk(tablename TEXT, columnname TEXT, mquery TEXT, k INT, algo TEXT DEFAULT '', stopwordslanguage TEXT DEFAULT '') RETURNS TABLE(id INTEGER, score double precision, doc TEXT)
-LANGUAGE plpgsql
+    LANGUAGE plpgsql
+    PARALLEL SAFE
+    STABLE
 AS $$
 DECLARE
-  docstname TEXT := tablename || '_' ||  columnname || '_bm25i_docs' || algo;
-  wordstname TEXT := tablename || '_' ||  columnname || '_bm25i_words' || algo;
+    docstname TEXT := tablename || '_' ||  columnname || '_bm25i_docs' || algo;
+    wordstname TEXT := tablename || '_' ||  columnname || '_bm25i_words' || algo;
 BEGIN
-  RETURN QUERY EXECUTE FORMAT( 'SELECT t1.id, t2.score, t1.%s AS doc FROM (SELECT id, doc AS %s FROM %s) t1 INNER JOIN ( SELECT id, score FROM bm25isc(%s,%s,%s) ) t2 ON ( t1.id = t2.id ) ORDER BY t2.score DESC LIMIT %s;', columnname, columnname, docstname, quote_literal(wordstname), quote_literal(mquery), quote_literal(stopwordslanguage), k );
+    RETURN QUERY EXECUTE FORMAT( 'SELECT t1.id, t2.score, t1.d AS doc FROM (SELECT id, doc AS d FROM %s) t1 INNER JOIN ( SELECT id, score FROM bm25isc_alt(%s,%s,%s) ) t2 ON ( t1.id = t2.id ) ORDER BY t2.score DESC LIMIT %s;', docstname, quote_literal(wordstname), quote_literal(mquery), quote_literal(stopwordslanguage), k );
 END;
 $$;

--- a/plpgsql_bm25.sql
+++ b/plpgsql_bm25.sql
@@ -412,12 +412,12 @@ $$;
 /* bm25scorerows() get the documentscores row for each word */
 DROP FUNCTION IF EXISTS bm25scorerows;
 CREATE OR REPLACE FUNCTION bm25scorerows(tablename TEXT, mquery TEXT, stopwordslanguage TEXT DEFAULT '') RETURNS SETOF double precision[]
-    LANGUAGE plpgsql
-    STABLE
-    PARALLEL SAFE
+  LANGUAGE plpgsql
+  STABLE
+  PARALLEL SAFE
 AS $$
 BEGIN
-    RETURN QUERY EXECUTE FORMAT('SELECT wsmap FROM %s w INNER JOIN unnest(stopwordfilter(bm25simpletokenize(%s), %s) n ON w.word = n.n;', tablename, quote_literal(mquery), stopwordslanguage);
+  RETURN QUERY EXECUTE FORMAT('SELECT wsmap FROM %s w INNER JOIN unnest(stopwordfilter(bm25simpletokenize(%s), %s) n ON w.word = n.n;', tablename, quote_literal(mquery), stopwordslanguage);
 END;
 $$;
 
@@ -429,47 +429,47 @@ LANGUAGE sql
 PARALLEL SAFE
 STABLE
 BEGIN ATOMIC
-    SELECT ARRAY_AGG(sum ORDER BY ord)
-    FROM (SELECT ord, SUM(int)
-          FROM (SELECT b.b
-                FROM bm25scorerows(tablename, quote_literal(mquery), quote_literal(stopwordslanguage)) b) t, unnest(t.b) WITH ORDINALITY u(int, ord)
-          GROUP BY ord) AS subquery;
+  SELECT ARRAY_AGG(sum ORDER BY ord)
+  FROM (SELECT ord, SUM(int)
+        FROM (SELECT b.b
+              FROM bm25scorerows(tablename, quote_literal(mquery), quote_literal(stopwordslanguage)) b) t, unnest(t.b) WITH ORDINALITY u(int, ord)
+        GROUP BY ord) AS subquery;
 END;
 
 
 /* bm25scunnest(): unnests the score array */
 DROP FUNCTION IF EXISTS bm25scunnest;
 CREATE OR REPLACE FUNCTION bm25scunnest(tablename TEXT, mquery TEXT, stopwordslanguage TEXT DEFAULT '') RETURNS TABLE(score double precision)
-    LANGUAGE sql
-    PARALLEL SAFE
-    STABLE
+  LANGUAGE sql
+  PARALLEL SAFE
+  STABLE
 BEGIN ATOMIC
-    SELECT unnest( bm25scoressum( tablename, mquery, stopwordslanguage ) );
+  SELECT unnest( bm25scoressum( tablename, mquery, stopwordslanguage ) );
 END;
 
 
 /* bm25isc(): returns the index and score of the documents; index starts with 1 */
 DROP FUNCTION IF EXISTS bm25isc;
 CREATE OR REPLACE FUNCTION bm25isc(tablename TEXT, mquery TEXT, stopwordslanguage TEXT DEFAULT '') RETURNS TABLE(id BIGINT, score double precision)
-    LANGUAGE sql
-    PARALLEL SAFE
-    STABLE
+  LANGUAGE sql
+  PARALLEL SAFE
+  STABLE
 BEGIN ATOMIC
-    SELECT row_number() OVER () AS id, bm25scunnest FROM bm25scunnest( tablename, mquery, stopwordslanguage ) ;
+  SELECT row_number() OVER () AS id, bm25scunnest FROM bm25scunnest( tablename, mquery, stopwordslanguage ) ;
 END;
 
 
 /* bm25topk(): returns the index, score and document sorted and limited |  TABLE(id INT, id2 BIGINT, score double precision, doc TEXT) */
 DROP FUNCTION IF EXISTS bm25topk;
 CREATE OR REPLACE FUNCTION bm25topk(tablename TEXT, columnname TEXT, mquery TEXT, k INT, algo TEXT DEFAULT '', stopwordslanguage TEXT DEFAULT '') RETURNS TABLE(id INTEGER, score double precision, doc TEXT)
-    LANGUAGE plpgsql
-    PARALLEL SAFE
-    STABLE
+  LANGUAGE plpgsql
+  PARALLEL SAFE
+  STABLE
 AS $$
 DECLARE
-    docstname TEXT := tablename || '_' ||  columnname || '_bm25i_docs' || algo;
-    wordstname TEXT := tablename || '_' ||  columnname || '_bm25i_words' || algo;
+  docstname TEXT := tablename || '_' ||  columnname || '_bm25i_docs' || algo;
+  wordstname TEXT := tablename || '_' ||  columnname || '_bm25i_words' || algo;
 BEGIN
-    RETURN QUERY EXECUTE FORMAT( 'SELECT t1.id, t2.score, t1.d AS doc FROM (SELECT id, doc AS d FROM %s) t1 INNER JOIN ( SELECT id, score FROM bm25isc_alt(%s,%s,%s) ) t2 ON ( t1.id = t2.id ) ORDER BY t2.score DESC LIMIT %s;', docstname, quote_literal(wordstname), quote_literal(mquery), quote_literal(stopwordslanguage), k );
+  RETURN QUERY EXECUTE FORMAT( 'SELECT t1.id, t2.score, t1.d AS doc FROM (SELECT id, doc AS d FROM %s) t1 INNER JOIN ( SELECT id, score FROM bm25isc_alt(%s,%s,%s) ) t2 ON ( t1.id = t2.id ) ORDER BY t2.score DESC LIMIT %s;', docstname, quote_literal(wordstname), quote_literal(mquery), quote_literal(stopwordslanguage), k );
 END;
 $$;

--- a/plpgsql_bm25.sql
+++ b/plpgsql_bm25.sql
@@ -417,7 +417,7 @@ CREATE OR REPLACE FUNCTION bm25scorerows(tablename TEXT, mquery TEXT, stopwordsl
   PARALLEL SAFE
 AS $$
 BEGIN
-  RETURN QUERY EXECUTE FORMAT('SELECT wsmap FROM %s w INNER JOIN unnest(stopwordfilter(bm25simpletokenize(%s), %s) n ON w.word = n.n;', tablename, quote_literal(mquery), stopwordslanguage);
+  RETURN QUERY EXECUTE FORMAT('SELECT wsmap FROM %s w INNER JOIN unnest(stopwordfilter(bm25simpletokenize(%s), %s)) n ON w.word = n.n;', tablename, quote_literal(mquery), stopwordslanguage);
 END;
 $$;
 


### PR DESCRIPTION
* Remove plgpsql loop in favor of SQL
* Simplify SQL in bm25topk()
* Use subquery instead of temp table to enable `PARALLEL SAFE`
* Add volatility and parallel classifications to bm25topk call-chain