### PR TITLE
Simplify topk call chain

### DIFF
--- a/plpgsql_bm25.sql
+++ b/plpgsql_bm25.sql
@@ -408,7 +408,7 @@ $$;
 
 
 /* bm25scorerows() get the documentscores row for each word */
-DROP FUNCTION IF EXISTS bm25scorerows;
+DROP FUNCTION IF EXISTS bm25scorerows CASCADE;
 CREATE OR REPLACE FUNCTION bm25scorerows(tablename TEXT, mquery TEXT, stopwordslanguage TEXT DEFAULT '') RETURNS SETOF double precision[]
   LANGUAGE plpgsql
   STABLE
@@ -422,38 +422,16 @@ $$;
 
 /* bm25scoressum(): sums the score rows to one array with the document scores ; TODO: test whether temp table fixes race condition here */
 DROP FUNCTION IF EXISTS bm25scoressum;
-CREATE OR REPLACE FUNCTION bm25scoressum(tablename TEXT, mquery TEXT, stopwordslanguage TEXT DEFAULT '') RETURNS SETOF double precision[]
+CREATE OR REPLACE FUNCTION bm25scoressum(tablename TEXT, mquery TEXT, stopwordslanguage TEXT DEFAULT '') RETURNS TABLE(id BIGINT, score double precision)
 LANGUAGE sql
 PARALLEL SAFE
 STABLE
 BEGIN ATOMIC
-  SELECT ARRAY_AGG(sum ORDER BY ord)
-  FROM (SELECT ord, SUM(int)
+  SELECT ord AS id, s AS score
+  FROM (SELECT ord, SUM(int) AS s
         FROM (SELECT b.b
               FROM bm25scorerows(tablename, quote_literal(mquery), quote_literal(stopwordslanguage)) b) t, unnest(t.b) WITH ORDINALITY u(int, ord)
-        GROUP BY ord) AS subquery;
-END;
-
-
-/* bm25scunnest(): unnests the score array */
-DROP FUNCTION IF EXISTS bm25scunnest;
-CREATE OR REPLACE FUNCTION bm25scunnest(tablename TEXT, mquery TEXT, stopwordslanguage TEXT DEFAULT '') RETURNS TABLE(score double precision)
-  LANGUAGE sql
-  PARALLEL SAFE
-  STABLE
-BEGIN ATOMIC
-  SELECT unnest( bm25scoressum( tablename, mquery, stopwordslanguage ) );
-END;
-
-
-/* bm25isc(): returns the index and score of the documents; index starts with 1 */
-DROP FUNCTION IF EXISTS bm25isc;
-CREATE OR REPLACE FUNCTION bm25isc(tablename TEXT, mquery TEXT, stopwordslanguage TEXT DEFAULT '') RETURNS TABLE(id BIGINT, score double precision)
-  LANGUAGE sql
-  PARALLEL SAFE
-  STABLE
-BEGIN ATOMIC
-  SELECT row_number() OVER () AS id, bm25scunnest FROM bm25scunnest( tablename, mquery, stopwordslanguage ) ;
+        GROUP BY ord ORDER BY ord) AS subquery;
 END;
 
 
@@ -468,6 +446,6 @@ DECLARE
   docstname TEXT := tablename || '_' ||  columnname || '_bm25i_docs' || algo;
   wordstname TEXT := tablename || '_' ||  columnname || '_bm25i_words' || algo;
 BEGIN
-  RETURN QUERY EXECUTE FORMAT( 'SELECT t1.id, t2.score, t1.d AS doc FROM (SELECT id, doc AS d FROM %s) t1 INNER JOIN ( SELECT id, score FROM bm25isc(%s,%s,%s) ) t2 ON ( t1.id = t2.id ) ORDER BY t2.score DESC LIMIT %s;', docstname, quote_literal(wordstname), quote_literal(mquery), quote_literal(stopwordslanguage), k );
+  RETURN QUERY EXECUTE FORMAT( 'SELECT t1.id, t2.score, t1.d AS doc FROM (SELECT id, doc AS d FROM %s) t1 INNER JOIN ( SELECT id, score FROM bm25scoressum(%s,%s,%s) ) t2 ON ( t1.id = t2.id ) ORDER BY t2.score DESC LIMIT %s;', docstname, quote_literal(wordstname), quote_literal(mquery), quote_literal(stopwordslanguage), k );
 END;
 $$;


### PR DESCRIPTION
Remove 2 unneeded functions. Add `CASCADE` to `DROP FUNCTION scorerows` - due to reference checking of `BEGIN ATOMIC`